### PR TITLE
Update interface version and add category to toc

### DIFF
--- a/PetPet.toc
+++ b/PetPet.toc
@@ -1,4 +1,4 @@
-## Interface: 120000, 11508, 20504, 30405, 40402, 50503
+## Interface: 120000, 11508, 20504, 30405, 40402, 50504
 ## X-Curse-Project-ID: 686613
 ## Title: |cffff8fe3P|r|cffff9ae6e|r|cffffa5e9t|r|cffffb1ebP|r|cffffbceee|r|cffffc7f1t|r
 ## Notes: Summon a random pet when you start moving.
@@ -8,6 +8,7 @@
 ## DefaultState: Enabled
 ## LoadOnDemand: 0
 ## SavedVariables: PetPetDB
-## IconTexture: Interface\Icons\ability_rogue_rollthebones
+## Category: Battle Pets
+## IconTexture: Interface\Icons\check comments
 
 PetPet.lua


### PR DESCRIPTION
1. client update 2 they added catagory to addons
3 logo only works for retail i found those related to your logo https://www.wowhead.com/mop-classic/item=36863/decahedral-dwarven-dice#icon https://www.wowhead.com/mop-classic/spell=134635/10-battle-pet-xp#icon https://www.wowhead.com/mop-classic/spell=243819/summon-random-favorite-battle-pet#icon

or use your curseforge logo by make it a 32x32 and make it .tga then change raw 12 to 
## IconTexture: Interface\AddOns\PetPet\icon (or whatever u want to name it)

and everything works in the latest mop patch.